### PR TITLE
[BUGFIX] Handle messages with parts and attachments only

### DIFF
--- a/Classes/Mail/Plugin/CssInlinerPlugin.php
+++ b/Classes/Mail/Plugin/CssInlinerPlugin.php
@@ -87,6 +87,8 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
      */
     private function looksLikeHtmlPart(\Swift_Mime_MimePart $entity): bool
     {
-        return $entity->getContentType() === 'multipart/mixed' && strpos($entity->getBody(), '<') !== false;
+        return $entity->getContentType() === 'multipart/mixed'
+            && !empty($entity->getBody())
+            && strpos($entity->getBody(), '<') !== false;
     }
 }

--- a/Tests/Unit/Mail/Plugin/CssInlinerPluginTest.php
+++ b/Tests/Unit/Mail/Plugin/CssInlinerPluginTest.php
@@ -97,4 +97,25 @@ class CssInlinerPluginTest extends UnitTestCase
 
         $this->assertEquals('<p>after</p>', $message->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function handlesMessagesWithPartsAndAttachmentsOnly()
+    {
+        /** @var MailMessage */
+        $message = GeneralUtility::makeInstance(MailMessage::class);
+        $message
+            ->addPart('<p>before</p>', 'text/html')
+            ->attach(new \Swift_Attachment('TEST', 'test.pdf', 'application/pdf'));
+        /** @var \Swift_Events_SendEvent|\Prophecy\Prophecy\ObjectProphecy */
+        $event = $this->prophesize(\Swift_Events_SendEvent::class);
+        $event->getMessage()->willReturn($message);
+
+        $this->converter->convert('<p>before</p>')->willReturn('<p>after</p>');
+
+        $this->cssInlinerPlugin->beforeSendPerformed($event->reveal());
+
+        $this->assertEquals('<p>after</p>', $message->getChildren()[0]->getBody());
+    }
 }


### PR DESCRIPTION
There are cases where messages do not have any body at all but parts
and attachments. This is e.g. the default result when sending mails
via Formhandler with files attached.

Fixes #4