### PR TITLE
Drop ssh-agent/-key from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,8 @@ services:
     depends_on:
       - mail
       - mysql
-      - ssh-key
     volumes:
       - ./:/var/www/html
-      - ssh-agent:/.ssh-agent
 
   mysql:
     image: mysql:5.7
@@ -35,20 +33,3 @@ services:
 
   mail:
     image: mailhog/mailhog:v1.0.1
-
-  ssh-agent:
-    image: docksal/ssh-agent:1.3
-    volumes:
-      - ssh-agent:/.ssh-agent
-
-  ssh-key:
-    image: docksal/ssh-agent:1.3
-    command: ['bash', '-c', 'ssh-add - </tmp/host-ssh/id_rsa']
-    depends_on:
-      - ssh-agent
-    volumes:
-      - $HOME/.ssh:/tmp/host-ssh:ro
-      - ssh-agent:/.ssh-agent
-
-volumes:
-  ssh-agent:


### PR DESCRIPTION
We do not really need this.