### PR TITLE
Disable php-http/discovery Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true,
             "typo3/class-alias-loader": true,
-            "typo3/cms-composer-installers": true
+            "typo3/cms-composer-installers": true,
+            "php-http/discovery": false
         },
         "sort-packages": true
     },


### PR DESCRIPTION
From its description we don't need this plugin:

> provides a composer plugin that automatically installs well-known PSR implementations if composer dependencies require a PSR implementation but do not specify which implementation to install