### PR TITLE
Skip empty HTML body in Fluid mails

### DIFF
--- a/Classes/Mail/FluidEmail.php
+++ b/Classes/Mail/FluidEmail.php
@@ -20,8 +20,10 @@ class FluidEmail extends CoreFluidEmail
      */
     public function html($body, string $charset = 'utf-8')
     {
-        $converter = new CssToInlineStyles();
-        $body = $converter->convert($body);
+        if (!empty($body)) {
+            $converter = new CssToInlineStyles();
+            $body = $converter->convert($body);
+        }
 
         return parent::html($body, $charset);
     }


### PR DESCRIPTION
TYPO3 v11.5.27 introduced a change in the way FluidEmails are processed which results in the HTML body of Fluid mails to sometimes be empty.

Avoid CSS inline style conversion in this case since this would fail with an error and is pointless to begin with.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/78251

Fixes #66