### PR TITLE
Mirror "php" dependency to ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,6 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '3.1.0',
     'constraints' => [
         'depends' => [
+            'php' => '8.0.0-8.99.99',
             'typo3' => '11.5.0-12.4.99',
         ],
     ],


### PR DESCRIPTION
This is essential for installations in Legacy Mode.

Fixes https://github.com/pagemachine/typo3-mail-css-inliner/issues/76