### PR TITLE
Explicitly require all dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
+        "symfony/mailer": "^5.4 || ^6.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2",
         "typo3/cms-core": "^11.5 || ^12.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.0",
         "symfony/mailer": "^5.4 || ^6.4",
+        "symfony/mime": "^5.4 || ^6.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2",
         "typo3/cms-core": "^11.5 || ^12.4"
     },


### PR DESCRIPTION
Using https://packagist.org/packages/maglnet/composer-require-checker

```
$ composer-require-checker check composer.json
ComposerRequireChecker 4.7.1@e49c58b18fef21e37941a642c1a70d3962e86f28
The following 3 unknown symbols were found:
+-----------------------------------+--------------------+
| Unknown Symbol                    | Guessed Dependency |
+-----------------------------------+--------------------+
| Symfony\Component\Mailer\Envelope |                    |
| Symfony\Component\Mime\Email      |                    |
| Symfony\Component\Mime\RawMessage |                    |
+-----------------------------------+--------------------+
```